### PR TITLE
Proof of concept test memory alloc hooks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ IF (MSVC)
 	SET(CMAKE_C_FLAGS_RELEASE "/MT /O2")
 	SET(WIN_RC "src/win32/git2.rc")
 ELSE ()
-	SET(CMAKE_C_FLAGS "-O2 -g -Wall -Wextra -Wno-missing-field-initializers -Wstrict-aliasing=2 -Wstrict-prototypes -Wmissing-prototypes ${CMAKE_C_FLAGS}")
+	SET(CMAKE_C_FLAGS "-O2 -g -Wall -Wextra -Wno-missing-field-initializers -Wno-unused-value -Wstrict-aliasing=2 -Wstrict-prototypes -Wmissing-prototypes ${CMAKE_C_FLAGS}")
 	SET(CMAKE_C_FLAGS_DEBUG "-O0 -g")
 	IF (NOT MINGW) # MinGW always does PIC and complains if we tell it to
 		SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
@@ -144,6 +144,8 @@ ENDIF ()
 IF (BUILD_CLAY)
 	SET(CLAY_FIXTURES "${CMAKE_CURRENT_SOURCE_DIR}/tests/resources/")
 	ADD_DEFINITIONS(-DCLAY_FIXTURE_PATH=\"${CLAY_FIXTURES}\")
+
+	ADD_DEFINITIONS(-DTEST_ALLOC)
 
     INCLUDE_DIRECTORIES(tests-clay)
 	FILE(GLOB_RECURSE SRC_TEST tests-clay/*.c)

--- a/src/global.h
+++ b/src/global.h
@@ -15,6 +15,10 @@ typedef struct {
 	} error;
 
 	git_mwindow_ctl mem_ctl;
+
+#ifdef TEST_ALLOC
+	git_alloc_monitor_fn alloc_cb;
+#endif
 } git_global_st;
 
 git_global_st *git__global_state(void);

--- a/tests-clay/core/path.c
+++ b/tests-clay/core/path.c
@@ -239,11 +239,28 @@ void test_core_path__7_path_to_dir(void)
 	check_string_to_dir("abcd", 6, "abcd/");
 }
 
+static int realloc_move(
+	int alloc_type, size_t GIT_UNUSED(size), void *GIT_UNUSED(ptr),
+	const char *GIT_UNUSED(file), size_t GIT_UNUSED(line))
+{
+	GIT_UNUSED_ARG(ptr);
+	GIT_UNUSED_ARG(size);
+	GIT_UNUSED_ARG(file);
+	GIT_UNUSED_ARG(line);
+
+	if (alloc_type == GIT_ALLOC_REALLOC)
+		return 1;
+	else
+		return 0;
+}
+
 /* join path to itself */
 void test_core_path__8_self_join(void)
 {
 	git_buf path = GIT_BUF_INIT;
 	ssize_t asize = 0;
+
+	git__alloc_monitor(realloc_move);
 
 	asize = path.asize;
 	cl_git_pass(git_buf_sets(&path, "/foo"));
@@ -270,6 +287,8 @@ void test_core_path__8_self_join(void)
 	cl_git_pass(git_buf_joinpath(&path, path.ptr + 4, "somethinglongenoughtorealloc"));
 	cl_assert_strequal(path.ptr, "/baz/somethinglongenoughtorealloc");
 	cl_assert(asize < path.asize);
-	
+
 	git_buf_free(&path);
+
+	git__alloc_monitor(NULL);
 }


### PR DESCRIPTION
This enables a new compile-time flag TEST_ALLOC which invokes an allocation hook prior to every malloc, realloc, free, etc. that can intercept and modify the behavior of the allocation.  By returning a value less than GIT_SUCCESS, the operation will be caused to fail.  For realloc, returning a value greater than 0, will cause a success but force the pointer to be moved.

As an added bit of paranoia, just enabling this will cause both realloc and free to write a zero byte to the old block before releasing it in an attempt to catch errors involving the use of an old buffer, and malloc will intentionally fill the block with garbage bytes.
